### PR TITLE
Fix incorrect way of checking UI Element names in Data Anonymization page raised in issue #19

### DIFF
--- a/CosmosClone/CosmicCloneUI/DataAnonymizationPage.xaml.cs
+++ b/CosmosClone/CosmicCloneUI/DataAnonymizationPage.xaml.cs
@@ -339,17 +339,16 @@ namespace CosmicCloneUI
                         if (uiElement.GetType().Name == "TextBox")
                         {
                             TextBox tb = (TextBox) uiElement;
-                            string name = tb.Name.Substring(0, tb.Name.Length - 1);
 
-                            if (name == "Filter")
+                            if (tb.Name.StartsWith("Filter"))
                             {
                                 sr.FilterCondition = tb.Text.Trim();
                             }
-                            else if (name == "ScrubAttribute")
+                            else if (tb.Name.StartsWith("ScrubAttribute"))
                             {
                                 sr.PropertyName = tb.Text.Trim();
                             }
-                            else if (name == "ScrubValue")
+                            else if (tb.Name.StartsWith("ScrubValue"))
                             {
                                 sr.UpdateValue = tb.Text.Trim();
                             }
@@ -358,8 +357,7 @@ namespace CosmicCloneUI
                         if (uiElement.GetType().Name == "ComboBox")
                         {
                             ComboBox cb = (ComboBox) uiElement;
-                            string name = cb.Name.Substring(0, cb.Name.Length - 1);
-                            if (name == "ScrubType")
+                            if (cb.Name.StartsWith("ScrubType"))
                             {
                                 //sr.Type = (RuleType) Enum.Parse(typeof(RuleType), cb.Text);
                                 RuleType rType;


### PR DESCRIPTION
- In Data Anonymization Rules page, TextBox and ComboBox names inside the Scrub Rule panel are created with the logic of appending the ruleIndex value (refer "CreateScrubRule" method). 

- But while trying to fetch the values of the scrub rule elements ( refer "getScrubRules" method), the logic used for retrieving the element name just takes the substring leaving the last character alone. This would return the expected values only for elements added with single-digit rule index and would result in validation error for elements with ruleIndex greater than 9.